### PR TITLE
Modify Action-and-Uri for Email intent, var args for addresses

### DIFF
--- a/library/src/main/java/com/marvinlabs/intents/EmailIntents.java
+++ b/library/src/main/java/com/marvinlabs/intents/EmailIntents.java
@@ -34,22 +34,8 @@ public class EmailIntents {
      * @param body    The body of the email (or null if not specified)
      * @return the intent
      */
-    public static Intent newEmailIntent(String address, String subject, String body) {
-        return newEmailIntent(address, subject, body, null);
-    }
-
-    /**
-     * Create an intent to send an email with an attachment to a single recipient
-     *
-     * @param address    The recipient address (or null if not specified)
-     * @param subject    The subject of the email (or null if not specified)
-     * @param body       The body of the email (or null if not specified)
-     * @param attachment The URI of a file to attach to the email. Note that the URI must point to a location the email
-     *                   application is allowed to read and has permissions to access.
-     * @return the intent
-     */
-    public static Intent newEmailIntent(String address, String subject, String body, Uri attachment) {
-        return newEmailIntent(address == null ? null : new String[]{address}, subject, body, attachment);
+    public static Intent newEmailIntent(String subject, String body, String address) {
+        return newEmailIntent(subject, body, null, address);
     }
 
     /**
@@ -62,16 +48,14 @@ public class EmailIntents {
      *                   application is allowed to read and has permissions to access.
      * @return the intent
      */
-    public static Intent newEmailIntent(String[] addresses, String subject, String body, Uri attachment) {
-        Intent intent = new Intent(Intent.ACTION_SEND);
+    public static Intent newEmailIntent(String subject, String body, Uri attachment, String... addresses) {
+        Intent intent = new Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:"));
         if (addresses != null) intent.putExtra(Intent.EXTRA_EMAIL, addresses);
         if (body != null) intent.putExtra(Intent.EXTRA_TEXT, body);
         if (subject != null) intent.putExtra(Intent.EXTRA_SUBJECT, subject);
         if (attachment != null) intent.putExtra(Intent.EXTRA_STREAM, attachment);
-        intent.setType(MIME_TYPE_EMAIL);
 
         return intent;
     }
 
-    private static final String MIME_TYPE_EMAIL = "message/rfc822";
 }


### PR DESCRIPTION
Main problem is: `MIME_TYPE_EMAIL = "message/rfc822";` is not only for email clients but for many others (e.g. with mhtml support), that's why user could end up opening evernote from many options, even if he has one default mail client.